### PR TITLE
Updated GetAsync overloads to expose blob metadata/properties.

### DIFF
--- a/src/Homely.Storage.Blobs/Blob.cs
+++ b/src/Homely.Storage.Blobs/Blob.cs
@@ -1,0 +1,7 @@
+﻿namespace Homely.Storage.Blobs
+{
+    public class Blob<T> : BlobBase
+    {
+        public T Data { get; set; }
+    }
+}

--- a/src/Homely.Storage.Blobs/BlobBase.cs
+++ b/src/Homely.Storage.Blobs/BlobBase.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Azure.Storage.Blob;
+using System.Collections.Generic;
+
+namespace Homely.Storage.Blobs
+{
+    public abstract class BlobBase
+    {
+        public BlobProperties Properties { get; set; }
+        public IDictionary<string, string> Metadata { get; set; }
+    }
+}

--- a/src/Homely.Storage.Blobs/BlobStream.cs
+++ b/src/Homely.Storage.Blobs/BlobStream.cs
@@ -1,0 +1,9 @@
+﻿using System.IO;
+
+namespace Homely.Storage.Blobs
+{
+    public class BlobStream : BlobBase
+    {
+        public Stream Stream { get; set; }        
+    }
+}

--- a/src/Homely.Storage.Blobs/IBlob.cs
+++ b/src/Homely.Storage.Blobs/IBlob.cs
@@ -16,7 +16,7 @@ namespace Homely.Storage.Blobs
         /// <param name="blobName">string: The identifier/name of this content to be stored on Azure.</param>
         /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
         /// <returns>A System.Threading.Tasks.Task object that represents the asynchronous operation.</returns>
-        Task<Stream> GetAsync(string blobName, CancellationToken cancellationToken = default);
+        Task<BlobStream> GetAsync(string blobName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves an item from Azure Blob storage.
@@ -26,7 +26,7 @@ namespace Homely.Storage.Blobs
         /// <param name="blobName">string: The identifier/name of this content to be stored on Azure.</param>
         /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
         /// <returns>A System.Threading.Tasks.Task object that represents the asynchronous operation.</returns>
-        Task<T> GetAsync<T>(string blobName, CancellationToken cancellationToken = default);
+        Task<Blob<T>> GetAsync<T>(string blobName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes an item from Azure blob storage.
@@ -43,10 +43,12 @@ namespace Homely.Storage.Blobs
         /// <remarks>Default encoding is set as UTF8.<br/>The item to store must be serializable.</remarks>
         /// <param name="item">object: the item to store in the azure blob.</param>
         /// <param name="blobId">Optional. The identifier/name of this content to be stored on Azure. If not supplied, then a new <code>Guid</code> will be used.</param>
+        /// <param name="contentType">Optional. What type of content exists in the file. If none is provided, then Azure defaults this value to <code>application/octet-stream</code>.</param>
         /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
         /// <returns>string: blob name.</returns>
         Task<string> AddAsync(object item, 
                               string blobId = null,
+                              string contentType = null,
                               CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -55,13 +57,15 @@ namespace Homely.Storage.Blobs
         /// </summary>
         /// <remarks>The item to store must be serializable.</remarks>
         /// <param name="item">object: the item to store in the azure blob.</param>
-        /// <param name="blobId">The identifier/name of this content to be stored on Azure. If <code>null</code>, then a new <code>Guid</code> will be used.</param>
+        /// <param name="blobId">The identifier/name of this content to be stored on Azure. If <code>null</code>, then a new <code>Guid</code> will be used.</param>        
         /// <param name="encoding">The encoding type to serialize the <code>item</code>.</param>
+        /// <param name="contentType">Optional. What type of content exists in the file. If none is provided, then Azure defaults this value to <code>application/octet-stream</code>.</param>
         /// <param name="cancellationToken">A System.Threading.CancellationToken to observe while waiting for a task to complete.</param>
         /// <returns>string: blob name.</returns>
         Task<string> AddAsync(object item,
                               string blobId,
                               Encoding encoding,
+                              string contentType = null,
                               CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/tests/Homely.Storage.Blobs.Tests/AddAsyncTests.cs
+++ b/tests/Homely.Storage.Blobs.Tests/AddAsyncTests.cs
@@ -22,7 +22,7 @@ namespace Homely.Storage.Blobs.Tests
             // Assert.
             blobId.ShouldNotBeNullOrEmpty();
             var blob = await azureBlob.GetAsync<SomeFakeUser>(blobId);
-            blob.ShouldLookLike(TestUser);
+            blob.Data.ShouldLookLike(TestUser);
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace Homely.Storage.Blobs.Tests
             // Assert.
             blobId.ShouldNotBeNullOrEmpty();
             var blob = await azureBlob.GetAsync<string>(blobId);
-            blob.ShouldLookLike(text);
+            blob.Data.ShouldLookLike(text);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace Homely.Storage.Blobs.Tests
             // Assert.
             blobId.ShouldNotBeNullOrEmpty();
             var blob = await azureBlob.GetAsync<SomeFakeUser>(blobId);
-            blob.ShouldLookLike(TestUser);
+            blob.Data.ShouldLookLike(TestUser);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Homely.Storage.Blobs.Tests
             // Assert.
             blobId.ShouldNotBeNullOrWhiteSpace();
             var blob = await azureBlob.GetAsync<string>(blobId);
-            blob.ShouldLookLike(asciiText);
+            blob.Data.ShouldLookLike(asciiText);
         }
 
         [Fact]
@@ -97,14 +97,14 @@ namespace Homely.Storage.Blobs.Tests
             byte[] existingBytes;
             using (var ms = new MemoryStream())
             {
-                existingBlob.Position = 0;
-                existingBlob.CopyTo(ms);
+                existingBlob.Stream.Position = 0;
+                existingBlob.Stream.CopyTo(ms);
                 existingBytes = ms.ToArray();
             }
 
             existingBytes.Length.ShouldBe(bytes.Length);
 
-            existingBlob.Dispose();
+            existingBlob.Stream.Dispose();
         }
 
         [Fact]
@@ -122,7 +122,7 @@ namespace Homely.Storage.Blobs.Tests
 
             var existingBlob = await azureBlob.GetAsync(blobId);
             existingBlob.ShouldNotBeNull();
-            existingBlob.Length.ShouldBeGreaterThan(0);
+            existingBlob.Stream.Length.ShouldBeGreaterThan(0);
         }
 
         [Fact(Skip = "Azurite is unable to handle 'copy'ing Uri's. As such, the test will fail because Azurite throws an exception.")]
@@ -138,7 +138,7 @@ namespace Homely.Storage.Blobs.Tests
             // Assert.
             var existingBlob = await azureBlob.GetAsync(blobId);
             existingBlob.ShouldNotBeNull();
-            existingBlob.Length.ShouldBeGreaterThan(0);
+            existingBlob.Stream.Length.ShouldBeGreaterThan(0);
         }
     }
 }

--- a/tests/Homely.Storage.Blobs.Tests/AddBatchAsyncTests.cs
+++ b/tests/Homely.Storage.Blobs.Tests/AddBatchAsyncTests.cs
@@ -33,8 +33,8 @@ namespace Homely.Storage.Blobs.Tests
             foreach(var blobId in blobIds)
             {
                 var existingUser = await azureBlob.GetAsync<SomeFakeUser>(blobId);
-                users.ShouldContain(x => x.Name == existingUser.Name && 
-                                         x.Age == existingUser.Age);
+                users.ShouldContain(x => x.Name == existingUser.Data.Name && 
+                                         x.Age == existingUser.Data.Age);
             }
         }
 
@@ -65,8 +65,8 @@ namespace Homely.Storage.Blobs.Tests
             foreach (var blobId in blobIds)
             {
                 var existingUser = await azureBlob.GetAsync<SomeFakeUser>(blobId);
-                existingUser.Name.ShouldBe(asciiText);
-                users.ShouldContain(x => x.Age == existingUser.Age);
+                existingUser.Data.Name.ShouldBe(asciiText);
+                users.ShouldContain(x => x.Age == existingUser.Data.Age);
             }
 
         }

--- a/tests/Homely.Storage.Blobs.Tests/CommonTestSetup.cs
+++ b/tests/Homely.Storage.Blobs.Tests/CommonTestSetup.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging.Abstractions;
-using Newtonsoft.Json;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -15,27 +14,26 @@ namespace Homely.Storage.Blobs.Tests
             Age = 40
         };
 
-        protected async Task<AzureBlob> GetAzureBlobAsync(bool setupInitialBlobData = true)
-        {
-            var logger = new NullLogger<AzureBlob>();
-            var blob = new AzureBlob("UseDevelopmentStorage=true", "test-container", logger);
+        protected AzureBlob Blob => new AzureBlob("UseDevelopmentStorage=true", "test-container", new NullLogger<AzureBlob>());
 
+        protected async Task<AzureBlob> GetAzureBlobAsync(bool setupInitialBlobData = true, string contentType = "text/plain")
+        {
             if (setupInitialBlobData)
             {
                 // Do we have the image already?
-                if (await blob.GetAsync(TestImageName) == null)
+                if (await Blob.GetAsync(TestImageName) == null)
                 {
                     var image = await File.ReadAllBytesAsync("2018-tesla-model-x-p100d.jpg");
-                    await blob.AddAsync(image, TestImageName);
+                    await Blob.AddAsync(image, contentType, TestImageName);
                 }
 
-                if (await blob.GetAsync<SomeFakeUser>(TestClassInstanceName) == null)
+                if (await Blob.GetAsync<SomeFakeUser>(TestClassInstanceName) == null)
                 {
-                    await blob.AddAsync(TestUser, TestClassInstanceName);
+                    await Blob.AddAsync(TestUser, TestClassInstanceName, contentType, default);
                 }
             }
 
-            return blob;
+            return Blob;
         }
     }
 }

--- a/tests/Homely.Storage.Blobs.Tests/GetAsyncTests.cs
+++ b/tests/Homely.Storage.Blobs.Tests/GetAsyncTests.cs
@@ -38,14 +38,16 @@ namespace Homely.Storage.Blobs.Tests
         public async Task GivenAnExistingClassInstance_GetAsyncGeneric_ReturnsTheInstance()
         {
             // Arrange.
-            var azureBlob = await GetAzureBlobAsync();
+            var contentType = "some/content-type";
+            await Blob.AddAsync(TestUser, TestClassInstanceName, contentType, default);
 
             // Act.
-            var user = await azureBlob.GetAsync<SomeFakeUser>(TestClassInstanceName);
+            var user = await Blob.GetAsync<SomeFakeUser>(TestClassInstanceName);
 
             // Assert.
             user.ShouldNotBeNull();
-            user.ShouldLookLike(TestUser);
+            user.Properties.ContentType.ShouldBe(contentType);
+            user.Data.ShouldLookLike(TestUser);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/Homely/Homely.Storage.Blobs/issues/1